### PR TITLE
fix: remove suffix from commit message (VF-1949)

### DIFF
--- a/default.json
+++ b/default.json
@@ -10,7 +10,6 @@
     ":labels(dependencies, ready for review)",
     "schedule:weekdays"
   ],
-  "commitMessageSuffix": "(VF-000)",
   "branchName": "{{{branchPrefix}}}{{{additionalBranchPrefix}}}{{{branchTopic}}}/VF-000",
   "rebaseWhen": "auto",
   "packageRules": [


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements VF-1949**

### Brief description. What is this change?

Removes the `(VF-000)` suffix from Renovatebot PRs in order to pass our PR title verification checks

<!-- Build up some context for your teammates on the changes made here and potential tradeoffs made and/or highlight any topics for discussion -->

### Implementation details. How do you make this change?

Removed the commitMessageSuffix configuration parameter


### Checklist

- [X] title of PR reflects the branch name
- [X] all commits adhere to conventional commits
