### PR TITLE
fix: use `:rebaseStalePrs` (VF-000)

### DIFF
--- a/default.json
+++ b/default.json
@@ -12,7 +12,6 @@
     ":rebaseStalePrs"
   ],
   "branchName": "{{{branchPrefix}}}{{{additionalBranchPrefix}}}{{{branchTopic}}}/VF-000",
-  "rebaseWhen": "auto",
   "packageRules": [
     {
       "matchPackagePatterns": ["*"],


### PR DESCRIPTION
**Fixes or implements VF-000**

### Brief description. What is this change?

Setting the rebase config to "auto" wasn't doing enough, this explicitly enables `:rebaseStalePrs` to rebase PRs as soon as they are behind the default branch.

### Checklist

- [ ] this is a breaking change and should publish a new major version
- [ ] appropriate tests have been written
