### PR TITLE
ci: all renovate pull requests should open as drafts

### DIFF
--- a/default.json
+++ b/default.json
@@ -12,6 +12,7 @@
     ":rebaseStalePrs"
   ],
   "branchName": "{{{branchPrefix}}}{{{additionalBranchPrefix}}}{{{branchTopic}}}/VF-000",
+  "draftPR": true,
   "packageRules": [
     {
       "matchPackagePatterns": ["*"],


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Part of VF-2100**

### Brief description. What is this change?

Adds default config to make all Renovatebot PRs open as drafts. This will prevent our rebase automations from unnecessarily rebasing Renovatebot PRs.


### Checklist

- [ ] this is a breaking change and should publish a new major version
- [ ] appropriate tests have been written
