### PR TITLE
ci: manage node dependencies for integrations team

### DIFF
--- a/integrations.json
+++ b/integrations.json
@@ -13,6 +13,16 @@
       ],
       "versioning": "node",
       "enabled": true
+    },
+    {
+      "matchManagers": [
+        "dockerfile", "docker-compose"
+      ],
+      "matchPackageNames": [
+        "node"
+      ],
+      "versioning": "node",
+      "enabled": true
     }
   ]
 }

--- a/integrations.json
+++ b/integrations.json
@@ -2,5 +2,17 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "description": "A base Renovate preset for the integrations team",
   "extends": ["github>voiceflow/renovate-config"],
-  "reviewers": ["jonahsnider"]
+  "reviewers": ["jonahsnider"],
+  "packageRules": [
+    {
+      "matchManagers": [
+        "npm"
+      ],
+      "matchPackageNames": [
+        "@types/node"
+      ],
+      "versioning": "node",
+      "enabled": true
+    }
+  ]
 }


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements VF-2220**

### Brief description. What is this change?

Adds management of node to Renovatebot for integrations repos.

### Checklist

- [ ] this is a breaking change and should publish a new major version
- [ ] appropriate tests have been written
