### PR TITLE
fix: improve branch name (VF-000)

### DIFF
--- a/default.json
+++ b/default.json
@@ -24,11 +24,13 @@
     },
     {
       "groupName": "Voiceflow dependencies",
+      "groupSlug": "vf-deps",
       "matchPackagePrefixes": ["@voiceflow/"],
       "enabled": true
     },
     {
       "groupName": "Voiceflow dependencies (automerge)",
+      "groupSlug": "vf-deps-automerge",
       "matchPackagePrefixes": ["@voiceflow/"],
       "matchUpdateTypes": ["minor", "patch", "pin"],
       "matchCurrentVersion": "!/^0/",


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements VF-000**

### Brief description. What is this change?

<img width="387" alt="image" src="https://user-images.githubusercontent.com/15315657/168150420-bcfd99dd-efc3-41ab-b207-117acfc8de1e.png">

Branch names are a bit weird, we should be able to change this with the [`groupSlug`](https://docs.renovatebot.com/configuration-options/#groupslug).
