### PR TITLE
chore(renovatebot): enable opening vulnerability PRs with renovatebot

### DIFF
--- a/default.json
+++ b/default.json
@@ -16,6 +16,9 @@
   "automerge": false,
   "automergeType": "pr-comment",
   "automergeComment": "bors r+",
+  "vulnerabilityAlerts": {
+      "enabled": true
+  },
   "packageRules": [
     {
       "matchPackagePatterns": ["*"],


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements VF-2226**

### Brief description. What is this change?

This enables [Vulnerability Alerts for renovatebot](https://www.mend.io/free-developer-tools/blog/new-feature-github-vulnerability-alerts/) across the org.

<!-- Build up some context for your teammates on the changes made here and potential tradeoffs made and/or highlight any topics for discussion -->

### Deployment Notes

This will require giving renovatebot permission to view the [vulnerability alerts](https://docs.renovatebot.com/configuration-options/#vulnerabilityalerts).

<!-- Notes regarding deployment the contained body of work. These should note any db migrations, etc. -->

### Checklist

- [ ] this is a breaking change and should publish a new major version
- [ ] appropriate tests have been written
